### PR TITLE
Support spaces in filenames

### DIFF
--- a/transmogrify_for_k8s_1.16.sh
+++ b/transmogrify_for_k8s_1.16.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Version: 0.1
+# Version: 0.2
 # Maintainer: @funkypenguin
 # Repo: https://github.com/funkypenguin/k8s-transmogrifier
 
@@ -23,18 +23,20 @@ then
 fi
 
 # Find all depreciation targets
-for i in `grep -liEr "kind: Deployment|kind: Daemonset|kind: Statefulset|kind: ReplicaSet" $TARGET`; do
-	if [[ `grep -E "extensions/v1beta1|apps/v1beta2|apps/v1beta1" $i` ]]; then
+mapfile -t files < <(grep -liEr "kind: Deployment|kind: Daemonset|kind: Statefulset|kind: ReplicaSet" "$TARGET")
+for i in "${files[@]}"; do
+	if [[ `grep -E "extensions/v1beta1|apps/v1beta2|apps/v1beta1" "$i"` ]]; then
 		echo "Deprecated API found in [$i].. Transmogrifying..."
-		sed -i -e "s|extensions/v1beta1|apps/v1|" $i
-		sed -i -e "s|apps/v1beta2|apps/v1|" $i
-		sed -i -e "s|apps/v1beta1|apps/v1|" $i
+		sed -i -e "s|extensions/v1beta1|apps/v1|" "$i"
+		sed -i -e "s|apps/v1beta2|apps/v1|" "$i"
+		sed -i -e "s|apps/v1beta1|apps/v1|" "$i"
 	fi
 done
 
-for i in `grep -liEr "kind: PodSecurityPolicy" $TARGET`; do
-	if [[ `grep -E "extensions/v1beta1|apps/v1beta2" $i` ]]; then
+mapfile -t files < <(grep -liEr "kind: PodSecurityPolicy" "$TARGET")
+for i in "${files[@]}"; do
+	if [[ `grep -E "extensions/v1beta1|apps/v1beta2" "$i"` ]]; then
 		echo "Deprecated API found in [$i].. Transmogrifying..."
-		sed -i -e "s|extensions/v1beta1|policy/v1beta1|" $i
+		sed -i -e "s|extensions/v1beta1|policy/v1beta1|" "$i"
 	fi
 done


### PR DESCRIPTION
Some of my directories contained spaces and the script failed on that, as the for loop considered the parts of the filename separately.
This change improves quoting and used the mapfile command (introduced in Bash version 4). I briefly tried setting the Internal Field Separator `$IFS` but couldn't get this to quickly, so I decided to disregard backwards compatibility and use the mapfile command.